### PR TITLE
Add direct wizard link from homepage

### DIFF
--- a/category-selector.html
+++ b/category-selector.html
@@ -184,7 +184,7 @@
         if (adviescollegeLink) {
           adviescollegeLink.href = `wizard-adviescollege.html?id=${docId}`;
         }
-        
+
         const convenantChecked = sessionStorage.getItem(`checked_convenant_${docId}`);
         if (convenantChecked === 'false') {
           // Add cross mark to Convenanten category
@@ -196,7 +196,7 @@
             crossMark.style.color = '#c62828';
             const title = convenantCard.querySelector('h3');
             if (title) title.appendChild(crossMark);
-            
+
             // Add a tooltip
             const tooltip = document.createElement('div');
             tooltip.textContent = 'Uit de wizard is gebleken dat dit waarschijnlijk geen convenant is.';
@@ -206,6 +206,13 @@
             const cardContent = convenantCard.querySelector('a, div');
             if (cardContent) cardContent.appendChild(tooltip);
           }
+        }
+      } else {
+        if (convenantLink) {
+          convenantLink.href = 'wizard.html';
+        }
+        if (adviescollegeLink) {
+          adviescollegeLink.href = 'wizard-adviescollege.html';
         }
       }
     });

--- a/index.html
+++ b/index.html
@@ -37,6 +37,24 @@
     }
   </script>
   <script src="/js/load-components.js"></script>
+  <style>
+    .wizard-section {
+      text-align: center;
+      margin: var(--space-md) 0;
+    }
+    .wizard-home-link {
+      display: inline-block;
+      padding: var(--space-sm) var(--space-md);
+      background: var(--color-primary);
+      color: #fff;
+      border-radius: var(--radius-sm);
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .wizard-home-link:hover {
+      background: #00437d;
+    }
+  </style>
 </head>
 <body>
   <!-- Header component will be loaded here -->
@@ -64,6 +82,9 @@
           <option value="In bewerking">In bewerking</option>
         </select>
       </form>
+    </section>
+    <section class="wizard-section">
+      <a href="wizard.html" class="wizard-home-link">Ik heb geen document maar wil toch de wizard doorlopen</a>
     </section>
 
     <!-- ======================

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
       </form>
     </section>
     <section class="wizard-section">
-      <a href="wizard.html" class="wizard-home-link">Ik heb geen document maar wil toch de wizard doorlopen</a>
+      <a href="category-selector.html" class="wizard-home-link">Ik heb geen document maar wil een wizard kiezen</a>
     </section>
 
     <!-- ======================


### PR DESCRIPTION
## Summary
- add CSS rules for a wizard link
- insert a homepage section with a button linking to `wizard.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684183d65b8c832ca4e353b70f5fab04