### PR TITLE
Add back navigation in wizards

### DIFF
--- a/wizard-adviescollege.html
+++ b/wizard-adviescollege.html
@@ -256,6 +256,7 @@
   (function() {
     const wizard = document.getElementById('wizard');
     const answers = [];
+    const history = [];
     let current = FLOW.start;
     const docId = new URLSearchParams(location.search).get('id');
 
@@ -276,12 +277,16 @@
         button('Ja', 'btn-yes', () => nextStep(id, 'yes')),
         button('Nee', 'btn-no', () => nextStep(id, 'no'))
       );
+      if (history.length) {
+        btnWrap.append(button('Vorige vraag', 'btn-neutral', goBack));
+      }
       wizard.append(btnWrap);
     }
 
     function nextStep(fromId, key) {
       const node = FLOW.nodes[fromId];
       const target = node[key];
+      history.push(fromId);
       answers.push((key === 'yes' ? '✔️ ' : '❌ ') + node.question);
 
       if (FLOW.results[target]) {
@@ -290,6 +295,14 @@
         current = target;
         render(current);
       }
+    }
+
+    function goBack() {
+      if (!history.length) return;
+      const prev = history.pop();
+      answers.pop();
+      current = prev;
+      render(current);
     }
 
     function renderResult(key) {
@@ -305,7 +318,10 @@
       }
 
       const btnWrap = create('div', null, 'wizard-buttons');
-      
+      if (history.length) {
+        btnWrap.append(button('Vorige vraag', 'btn-neutral', goBack));
+      }
+
       // Toon toewijsknop als het een adviescollege betreft
       if ((key === 'ADVIESCOLLEGE_RAPPORT' || key === 'ADVIESCOLLEGE_INTERN') && docId) {
         btnWrap.append(button('Categorie "Adviescollege" toewijzen', 'btn-yes', async () => {

--- a/wizard.html
+++ b/wizard.html
@@ -43,6 +43,7 @@
   (function() {
     const wizard = document.getElementById('wizard');
     const answers = [];
+    const history = [];
     let current = FLOW.start;
     const docId = new URLSearchParams(location.search).get('id');
 
@@ -63,12 +64,16 @@
         button('Ja', 'btn-yes', () => nextStep(id, 'yes')),
         button('Nee', 'btn-no', () => nextStep(id, 'no'))
       );
+      if (history.length) {
+        btnWrap.append(button('Vorige vraag', 'btn-neutral', goBack));
+      }
       wizard.append(btnWrap);
     }
 
     function nextStep(fromId, key) {
       const node = FLOW.nodes[fromId];
       const target = node[key];
+      history.push(fromId);
       answers.push((key === 'yes' ? '✔️ ' : '❌ ') + node.question);
 
       if (FLOW.results[target]) {
@@ -77,6 +82,14 @@
         current = target;
         render(current);
       }
+    }
+
+    function goBack() {
+      if (!history.length) return;
+      const prev = history.pop();
+      answers.pop();
+      current = prev;
+      render(current);
     }
 
     function renderResult(key) {
@@ -101,6 +114,9 @@
       }
 
       const btnWrap = create('div', null, 'wizard-buttons');
+      if (history.length) {
+        btnWrap.append(button('Vorige vraag', 'btn-neutral', goBack));
+      }
       if (docId) {
         if (key === 'CONVENANT_VASTGESTELD') {
           // Store in session that convenant was checked and is a match


### PR DESCRIPTION
## Summary
- add history stack logic to wizard.html and wizard-adviescollege.html
- add "Vorige vraag" button for navigating to the previous step

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68418cdf3520832c806353b76e934f5c