### PR TITLE
Add publication steps button for no-doc wizard flow

### DIFF
--- a/category-selector.html
+++ b/category-selector.html
@@ -56,6 +56,19 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .publicatie-button {
+      display: none;
+      margin-top: 1rem;
+      padding: var(--space-sm) var(--space-md);
+      background: var(--color-primary);
+      color: #fff;
+      border-radius: var(--radius-sm);
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .publicatie-button:hover {
+      background: #00437d;
+    }
   </style>
 </head>
 <body>
@@ -65,6 +78,7 @@
   <main class="container">
     <div class="page-header">
       <p>Kies hieronder bij welk type document het beste past. Elk type heeft een eigen wizard om u te helpen de juiste categorie te bepalen.</p>
+      <a id="publication-button" href="publicatie-stappen.html" class="publicatie-button">Publicatiestappen doorlopen</a>
     </div>
 
     <div class="category-grid">
@@ -170,12 +184,18 @@
     const urlParams = new URLSearchParams(window.location.search);
     const docId = urlParams.get('id');
     const fromWizard = urlParams.get('fromWizard') === 'true';
+    const noDoc = urlParams.get('noDoc') === 'true';
     
     // Check if we have a stored result for this document
     document.addEventListener('DOMContentLoaded', () => {
       // Set up the convenant and adviescollege links
       const convenantLink = document.getElementById('convenant-link');
       const adviescollegeLink = document.getElementById('adviescollege-link');
+      const publicationButton = document.getElementById('publication-button');
+
+      if (noDoc && publicationButton) {
+        publicationButton.style.display = 'inline-block';
+      }
       
       if (docId) {
         if (convenantLink) {

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
       </form>
     </section>
     <section class="wizard-section">
-      <a href="category-selector.html" class="wizard-home-link">Ik heb geen document maar wil een wizard kiezen</a>
+      <a href="category-selector.html?noDoc=true" class="wizard-home-link">Ik heb geen document maar wil een wizard kiezen</a>
     </section>
 
     <!-- ======================


### PR DESCRIPTION
## Summary
- pass a flag when starting a wizard without document
- show a link to the publication steps wizard only when that flag is present

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68419a2c5a48832cade5fa002d38c298